### PR TITLE
Override for AGVE token

### DIFF
--- a/packages/react-app/src/lib/overrides.js
+++ b/packages/react-app/src/lib/overrides.js
@@ -124,6 +124,21 @@ const DATATokenOverride = {
   },
 };
 
+const AGVETokenOverride = {
+  100: {
+    mediator: '0xBE20F60339b06Db32C319d46cf3Bc9bAcC0694aB',
+    from: '0x3a97704a1b25f08aa230ae53b352e2e72ef52843',
+    to: '0x0b006E475620Af076915257C6A9E40635AbdBBAd',
+    mode: 'dedicated-erc20',
+  },
+  1: {
+    mediator: '0x5689C65cfe5E8BF1A5F836c956DeA1b3B8BE00Bb',
+    from: '0x0b006E475620Af076915257C6A9E40635AbdBBAd',
+    to: '0x3a97704a1b25f08aa230ae53b352e2e72ef52843',
+    mode: 'erc677',
+  },
+};
+
 const ETH_XDAI_OVERRIDES = {
   ['0x0905Ab807F8FD040255F0cF8fa14756c1D824931'.toLowerCase()]: OWLTokenOverride,
   ['0x1a5f9352af8af974bfc03399e3767df6370d82e4'.toLowerCase()]: OWLTokenOverride,
@@ -139,6 +154,8 @@ const ETH_XDAI_OVERRIDES = {
   ['0x71850b7e9ee3f13ab46d67167341e4bdc905eef9'.toLowerCase()]: HNYTokenOverride,
   ['0x0cf0ee63788a0849fe5297f3407f701e122cc023'.toLowerCase()]: DATATokenOverride,
   ['0xE4a2620edE1058D61BEe5F45F6414314fdf10548'.toLowerCase()]: DATATokenOverride,
+  ['0x0b006E475620Af076915257C6A9E40635AbdBBAd'.toLowerCase()]: AGVETokenOverride,
+  ['0x3a97704a1b25f08aa230ae53b352e2e72ef52843'.toLowerCase()]: AGVETokenOverride,
 };
 
 const KOVAN_SOKOL_OVERRIDES = {

--- a/packages/subgraph/config/mainnet.json
+++ b/packages/subgraph/config/mainnet.json
@@ -23,6 +23,11 @@
       "name": "DATA",
       "address": "0x2eeeDdeECe91c9F4c5bA4C8E1d784A0234C6d015",
       "startBlock": "12004477"
+    },
+    {
+      "name": "AGVE",
+      "address": "0x5689C65cfe5E8BF1A5F836c956DeA1b3B8BE00Bb",
+      "startBlock": "12624668"
     }
   ]
 }

--- a/packages/subgraph/config/xdai.json
+++ b/packages/subgraph/config/xdai.json
@@ -23,6 +23,11 @@
       "name": "DATA",
       "address": "0x7d55f9981d4E10A193314E001b96f72FCc901e40",
       "startBlock": "14923817"
+    },
+    {
+      "name": "AGVE",
+      "address": "0xBE20F60339b06Db32C319d46cf3Bc9bAcC0694aB",
+      "startBlock": "16549014"
     }
   ]
 }

--- a/packages/subgraph/src/mappings/overrides.ts
+++ b/packages/subgraph/src/mappings/overrides.ts
@@ -48,6 +48,16 @@ export function getOverrides(): TypedMap<Address, boolean> {
       Address.fromString('0x0cf0ee63788a0849fe5297f3407f701e122cc023'),
       true,
     );
+    overriddenTokens.set(
+      // xdai AGVE
+      Address.fromString('0x3a97704a1b25f08aa230ae53b352e2e72ef52843'),
+      true,
+    );
+    overriddenTokens.set(
+      // mainnet AGVE
+      Address.fromString('0x0b006E475620Af076915257C6A9E40635AbdBBAd'),
+      true,
+    );
   } else if (direction == 'kovan-sokol') {
     overriddenTokens.set(
       // sokol DEMO2712
@@ -110,6 +120,16 @@ export function getMediatedTokens(): TypedMap<Address, Address> {
       // mainnet DATA
       Address.fromString('0x2eeeDdeECe91c9F4c5bA4C8E1d784A0234C6d015'),
       Address.fromString('0x0cf0ee63788a0849fe5297f3407f701e122cc023'),
+    );
+    mediatedTokens.set(
+      // xdai AGVE
+      Address.fromString('0xBE20F60339b06Db32C319d46cf3Bc9bAcC0694aB'),
+      Address.fromString('0x3a97704a1b25f08aa230ae53b352e2e72ef52843'),
+    );
+    mediatedTokens.set(
+      // mainnet AGVE
+      Address.fromString('0x5689C65cfe5E8BF1A5F836c956DeA1b3B8BE00Bb'),
+      Address.fromString('0x0b006E475620Af076915257C6A9E40635AbdBBAd'),
     );
   } else if (direction == 'kovan-sokol') {
     mediatedTokens.set(


### PR DESCRIPTION
Adds overrides for the $AGVE token, so it can be bridged from xDai to Ethereum through the Omnibridge UI.
https://agave.finance/