### PR TITLE
Enable reverse mode for ETH-xDAI bridge

### DIFF
--- a/packages/dapp/src/lib/networks.js
+++ b/packages/dapp/src/lib/networks.js
@@ -19,7 +19,7 @@ const ETH_XDAI_BRIDGE_CONFIG = {
   label: 'eth⥊xdai',
   homeChainId: 100,
   foreignChainId: 1,
-  enableReversedBridge: false,
+  enableReversedBridge: true,
   enableForeignCurrencyBridge: false,
   foreignMediatorAddress:
     '0x88ad09518695c6c3712AC10a214bE5109a655671'.toLowerCase(),


### PR DESCRIPTION
Verified on https://sokol-omnibridge.web.app/bridge with WXDAI:
- request: https://blockscout.com/poa/xdai/tx/0x48928972a928148fb8d624d78474ebadde04981b14e3510023292a59275c357e
- execution: https://etherscan.io/tx/0x5e822f386a73bd56ab3aacf1648ff66074d9b8bf62761154efe5cf3691ade70d