### PR TITLE
fix: remove fromToken max value formatting

### DIFF
--- a/packages/dapp/src/components/bridge/FromToken.jsx
+++ b/packages/dapp/src/components/bridge/FromToken.jsx
@@ -13,7 +13,7 @@ import { Logo } from 'components/common/Logo';
 import { SelectTokenModal } from 'components/modals/SelectTokenModal';
 import { useBridgeContext } from 'contexts/BridgeContext';
 import { useWeb3Context } from 'contexts/Web3Context';
-import { BigNumber } from 'ethers';
+import { BigNumber, utils } from 'ethers';
 import { formatValue, logError, truncateText } from 'lib/helpers';
 import { fetchTokenBalance } from 'lib/token';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -201,7 +201,7 @@ export const FromToken = () => {
               fontWeight="normal"
               _hover={{ bg: 'blue.100' }}
               onClick={() => {
-                const amountInput = formatValue(balance, token.decimals);
+                const amountInput = utils.formatUnits(balance, token.decimals);
                 setAmount(amountInput);
                 setInput(amountInput);
               }}


### PR DESCRIPTION
Closes https://github.com/omni/omnibridge-ui/issues/361.

`FromToken` input now matches the formatting of `ToToken`.

<img width="975" alt="Screen Shot 2022-05-18 at 3 12 38 pm" src="https://user-images.githubusercontent.com/97164662/168961879-e8f05f65-49d1-44dc-a0c6-b9750d17416c.png">

